### PR TITLE
Don't automock from pytest plugin setup, use fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -440,4 +440,4 @@ Now we can run the tests:
 
 .. code:: bash
 
-    make test
+    make -f MAKEFILE test

--- a/automock/pytest_plugin.py
+++ b/automock/pytest_plugin.py
@@ -1,9 +1,9 @@
-import automock
+import pytest
+
+import automock as automock_lib
 
 
-def pytest_runtest_setup(item):
-    automock.start_patching()
-
-
-def pytest_runtest_teardown(item):
-    automock.stop_patching()
+@pytest.fixture
+def automock():
+    with automock_lib.activate():
+        yield

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -14,7 +14,7 @@ from tests import dummies
 pytest_plugins = 'automock.pytest_plugin'
 
 
-def test_pytest_plugin():
+def test_pytest_plugin(automock):
     # plugin has patched our registered automocks
     assert dummies.func_to_mock() == 'I have large ears'
     assert dummies.other_func_to_mock() == 'I like PHP'


### PR DESCRIPTION
We need to be able to decide which tests need to be automocked on the
project using the library.

Calling automock from the pytest plugin setup means every test will get
automocked and there is no way to disable this behaviour.

A fixture is more flexible, since it can be invoked from any test that
requires it and it can be injected to every test in the same
module/package using an `autouse=True` fixture if necessary.